### PR TITLE
EDGEUSERS-2: Review/Resolve identified CVEs in edge-users

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.6</version>
+    <version>3.2.11</version>
     <relativePath />
   </parent>
 
@@ -36,7 +36,7 @@
     <snakeyaml.version>2.0</snakeyaml.version>
     <jknack.handlebars.version>4.3.1</jknack.handlebars.version>
     <tomcat.version>10.1.25</tomcat.version>
-    <bouncycastle.jdk18on.version>1.74</bouncycastle.jdk18on.version>
+    <bouncycastle.jdk18on.version>1.78</bouncycastle.jdk18on.version>
     <jackson.version>2.16.0</jackson.version>
     <commons-lang3.version>3.17.0</commons-lang3.version>
   </properties>


### PR DESCRIPTION
## Purpose
<!--
  Why are you making this change?  Provide the reviewer and future readers the cause that gave rise to this pull request. Include enough detail for a developer from another team to reconstruct the necessary context merely by reading this section.

  If you have a Rally ticket, include a link to it here.
 -->
https://folio-org.atlassian.net/browse/EDGEUSERS-2

## Approach
- Prisma scan identified a number of CVEs in Dreamliner's modules: edge-inventory, edge-users.
- Resolve all High and Critical statuses of the versions.

## Checklist
<!--
  This serves as gentle reminder for common tasks. Confirm these are done and check all that apply.
-->
- [x] Documentation updated
- [ ] Tests cover new or modified code
- [x] New dependencies added
- [ ] Includes breaking changes
- [ ] Module permissions been updated when calling new APIs
- [ ] The interface version has been bumped
- [ ] Coordinated corresponding changes in the UI and other backend modules that consume new interface 

## Result
### It was
<img width="717" alt="image" src="https://github.com/user-attachments/assets/7517bdba-282d-444b-9fc7-d2d3b2501090">

### It is now
<img width="715" alt="image" src="https://github.com/user-attachments/assets/35877b61-a498-4b58-89c5-e35fc52f5694">
