### PR TITLE
EDGEUSERS-9: Remove doUploadApidocs from Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,6 @@ buildMvn {
   publishModDescriptor = true
   mvnDeploy = true
   doKubeDeploy = true
-  doUploadApidocs = true
   buildNode = 'jenkins-agent-java21'
 
   doDocker = {


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/EDGEUSERS-9

We have switched to GitHub Workflows for [api-lint](https://dev.folio.org/guides/api-lint/) and [api-schema-lint](https://dev.folio.org/guides/describe-schema/) and [api-doc](https://dev.folio.org/guides/api-doc/): #7

They replace the Jenkins-operated CI stages, so we need to disable the Jenkins stage.