### PR TITLE
EDGEUSERS-11: Release 2.0.1 with Netty 4.1.130 and Tomcat 10.1.50 fixing vulns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## v2.0.1
+### Bug fixes
+- [EDGEUSERS-11](https://folio-org.atlassian.net/browse/EDGEUSERS-11) Netty 4.1.130, Tomcat 10.1.50 fixing vulns
+
 ## v2.0.0
 ### Features
 - Create New User

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>edge-users</artifactId>
-  <version>2.0.1</version>
+  <version>2.0.2-SNAPSHOT</version>
   <name>edge-users</name>
   <description>Provides an ability to retrieve and create users information from FOLIO</description>
   <packaging>jar</packaging>
@@ -295,7 +295,7 @@
     <url>https://github.com/folio-org/${project.artifactId}</url>
     <connection>scm:git:git://github.com/folio-org/${project.artifactId}.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/${project.artifactId}.git</developerConnection>
-    <tag>v2.0.1</tag>
+    <tag>v2.0.0</tag>
   </scm>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,8 @@
     <httpcomponents.httpcore.version>4.4.16</httpcomponents.httpcore.version>
     <snakeyaml.version>2.0</snakeyaml.version>
     <jknack.handlebars.version>4.3.1</jknack.handlebars.version>
-    <tomcat.version>10.1.25</tomcat.version>
+    <netty.version>4.1.130.Final</netty.version>
+    <tomcat.version>10.1.50</tomcat.version>
     <bouncycastle.jdk18on.version>1.78</bouncycastle.jdk18on.version>
     <jackson.version>2.16.0</jackson.version>
     <commons-lang3.version>3.17.0</commons-lang3.version>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>edge-users</artifactId>
-  <version>2.0.0</version>
+  <version>2.0.1-SNAPSHOT</version>
   <name>edge-users</name>
   <description>Provides an ability to retrieve and create users information from FOLIO</description>
   <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>edge-users</artifactId>
-  <version>2.0.1-SNAPSHOT</version>
+  <version>2.0.1</version>
   <name>edge-users</name>
   <description>Provides an ability to retrieve and create users information from FOLIO</description>
   <packaging>jar</packaging>
@@ -295,7 +295,7 @@
     <url>https://github.com/folio-org/${project.artifactId}</url>
     <connection>scm:git:git://github.com/folio-org/${project.artifactId}.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/${project.artifactId}.git</developerConnection>
-    <tag>v2.0.0</tag>
+    <tag>v2.0.1</tag>
   </scm>
 
   <repositories>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/EDGEUSERS-11

Fix security vulnerabilities for Ramsons CSP:

* CVE-2025-67735 - netty-codec-http - CRLF injection - https://folio-org.atlassian.net/browse/FOLIO-4430
* CVE-2025-24970 - netty-handler SSLEngine native crash - https://folio-org.atlassian.net/browse/FOLIO-4339
* CVE-2025-31650 - tomcat-embed-core DoS via HTTP priority header - https://folio-org.atlassian.net/browse/FOLIO-4316
* CVE-2025-53506 - tomcat-embed-core - HTTP/2 multiplex DoS - https://github.com/advisories/GHSA-25xr-qj8w-c4vf
* CVE-2025-48989 - tomcat-embed-core - HTTP/2 DoS - Made You Reset - https://folio-org.atlassian.net/browse/FOLIO-4369

Approach

In the Ramsons branch b2.1 upgrade

* Netty from 4.1.114.Final to 4.1.130.Final (by adding <netty.version>4.1.130.Final</netty.version>)
* Tomcat from 10.1.25 to 10.1.50 (by changing existing <tomcat.version> entry)

Release it as 2.0.1 Ramsons CSP.

Example: https://github.com/folio-org/edge-dcb/pull/79/changes