### PR TITLE
EDGEUSERS-17: Do self-evaluation for TC approval

### DIFF
--- a/.github/workflows/tc-evaluation.yml
+++ b/.github/workflows/tc-evaluation.yml
@@ -1,0 +1,44 @@
+name: TC Module Evaluation
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to evaluate (defaults to current ref)'
+        required: false
+        type: string
+      output_format:
+        description: 'Report format'
+        required: false
+        type: choice
+        options:
+          - both
+          - json-only
+          - html-only
+        default: 'both'
+      criteria_filter:
+        description: 'Comma-separated criterion IDs (e.g., S001,S002,B005). Leave empty for all.'
+        required: false
+        type: string
+      java_version:
+        description: 'Java version'
+        required: false
+        type: string
+        default: '21'
+      node_version:
+        description: 'Node.js version'
+        required: false
+        type: string
+        default: '20'
+
+jobs:
+  evaluate:
+    permissions:
+      contents: read
+    uses: folio-org/tc-module-eval/.github/workflows/evaluate.yml@master
+    with:
+      ref: ${{ inputs.ref }}
+      output_format: ${{ inputs.output_format }}
+      criteria_filter: ${{ inputs.criteria_filter }}
+      java_version: ${{ inputs.java_version }}
+      node_version: ${{ inputs.node_version }}

--- a/ENV_VARS.md
+++ b/ENV_VARS.md
@@ -8,7 +8,7 @@ Generic Spring Boot environment variables are supported by the framework and are
 | `JAVA_OPTIONS` | `-XX:MaxRAMPercentage=66.0` | false | Java runtime options for the module container. |
 | `SERVER_PORT` | `8080` | false | HTTP port used by the embedded Spring Boot server. |
 | `FOLIO_ENVIRONMENT` | `dev` | false | FOLIO environment name used by folio-spring-system-user configuration. |
-| `FOLIO_CLIENT_OKAPIURL` | `http://localhost:9130` | false | Okapi base URL used for outbound FOLIO service calls. |
+| `FOLIO_CLIENT_OKAPIURL` |  | true | Okapi base URL used for outbound FOLIO service calls. This must be set to the reachable Okapi URL for the deployment environment. |
 | `FOLIO_CLIENT_TLS_ENABLED` | `false` | false | Enables custom TLS truststore configuration for outbound Okapi/client calls. |
 | `FOLIO_CLIENT_TLS_TRUSTSTOREPATH` |  | false | Path to the outbound client TLS truststore. Required only when `FOLIO_CLIENT_TLS_ENABLED` is true and the server certificate is not trusted by the default JVM truststore. |
 | `FOLIO_CLIENT_TLS_TRUSTSTOREPASSWORD` |  | false | Password for the outbound client TLS truststore. |

--- a/ENV_VARS.md
+++ b/ENV_VARS.md
@@ -1,0 +1,27 @@
+# Environment Variables
+
+This table documents the operator-facing environment variables declared by `edge-users`.
+Generic Spring Boot environment variables are supported by the framework and are not exhaustively listed here.
+
+| Name | Default | Required | Description |
+| --- | --- | --- | --- |
+| `JAVA_OPTIONS` | `-XX:MaxRAMPercentage=66.0` | false | Java runtime options for the module container. |
+| `SERVER_PORT` | `8080` | false | HTTP port used by the embedded Spring Boot server. |
+| `FOLIO_ENVIRONMENT` | `dev` | false | FOLIO environment name used by folio-spring-system-user configuration. |
+| `FOLIO_CLIENT_OKAPIURL` | `http://localhost:9130` | false | Okapi base URL used for outbound FOLIO service calls. |
+| `FOLIO_CLIENT_TLS_ENABLED` | `false` | false | Enables custom TLS truststore configuration for outbound Okapi/client calls. |
+| `FOLIO_CLIENT_TLS_TRUSTSTOREPATH` |  | false | Path to the outbound client TLS truststore. Required only when `FOLIO_CLIENT_TLS_ENABLED` is true and the server certificate is not trusted by the default JVM truststore. |
+| `FOLIO_CLIENT_TLS_TRUSTSTOREPASSWORD` |  | false | Password for the outbound client TLS truststore. |
+| `FOLIO_CLIENT_TLS_TRUSTSTORETYPE` |  | false | Type of the outbound client TLS truststore, for example `JKS`, `PKCS12`, or `BCFKS`. If unset, the JVM default truststore type is used. |
+| `SECURE_STORE_PROPS` | `src/main/resources/ephemeral.properties` | false | Path or URL to the edge secure-store properties file used to configure the secure store for institutional user credentials. |
+| `API_KEY_SOURCES` | `PARAM,HEADER,PATH` | false | Comma-separated list of locations where the edge API key is accepted. Valid values are `PARAM`, `HEADER`, and `PATH`. |
+| `TOKEN_CACHE_TTL_MS` | `3600000` | false | Time to live, in milliseconds, for successful Okapi token cache entries. |
+| `NULL_TOKEN_CACHE_TTL_MS` | `30000` | false | Time to live, in milliseconds, for failed or null Okapi token cache entries. |
+| `TOKEN_CACHE_CAPACITY` | `100` | false | Maximum number of Okapi token entries held by the in-memory edge token cache. |
+| `EDGE_SECURITY_FILTER_ENABLED` | `true` | false | Enables the edge API key security filter. |
+| `HEADER_EDGE_VALIDATION_EXCLUDE` | `/admin/health,/admin/info,/swagger-resources,/v2/api-docs,/swagger-ui,/_/tenant` | false | Comma-separated list of request path prefixes excluded from edge API key validation. |
+
+## Framework Variables
+
+The module also runs on Spring Boot and supports standard Spring environment variables through framework relaxed binding.
+Examples include `SPRING_PROFILES_ACTIVE`, `SERVER_SSL_BUNDLE`, and `SPRING_SSL_BUNDLE_JKS_*` variables for TLS bundles.

--- a/MODULE_SELF_EVALUATION.md
+++ b/MODULE_SELF_EVALUATION.md
@@ -5,8 +5,8 @@
 * [x] Third party dependencies use an Apache 2.0 compatible license
 * [x] Installation documentation is included
     * -_note: read more at https://github.com/folio-org/mod-search/blob/master/README.md_
-* [] Personal data form is completed, accurate, and provided as `PERSONAL_DATA_DISCLOSURE.md` file
-* [] Sensitive and environment-specific information is not checked into git repository
+* [x] Personal data form is completed, accurate, and provided as `PERSONAL_DATA_DISCLOSURE.md` file
+* [x] Sensitive and environment-specific information is not checked into git repository
 * [x] Module is written in a language and framework from the [officially approved technologies](https://wiki.folio.org/display/TC/Officially+Supported+Technologies) page
 * [x] Module only uses FOLIO interfaces already provided by previously accepted modules _e.g. a UI module cannot be accepted that relies on an interface only provided by a back end module that hasn't been accepted yet_
 * [x] Module gracefully handles the absence of third party systems or related configuration

--- a/MODULE_SELF_EVALUATION.md
+++ b/MODULE_SELF_EVALUATION.md
@@ -18,7 +18,7 @@
 * [x] Module's repository includes a compliant Module Descriptor
     * -_note: read more at https://github.com/folio-org/okapi/blob/master/okapi-core/src/main/raml/ModuleDescriptor.json_
 * [x] Module includes executable implementations of all endpoints in the provides section of the Module Descriptor
-* [] Environment vars are documented in the ModuleDescriptor
+* [x] Environment vars are documented in the ModuleDescriptor
     * -_note: read more at [https://wiki.folio.org/pages/viewpage.action?pageId=65110683](https://wiki.folio.org/pages/viewpage.action?pageId=65110683)_
 * [x] If a module provides interfaces intended to be consumed by other FOLIO Modules, they must be defined in the Module Descriptor "provides" section
 * [x] All API endpoints are documented in RAML or OpenAPI
@@ -40,4 +40,3 @@
         * Services are stateful
 * [x] Module only uses infrastructure / platform technologies on the [officially approved technologies](https://wiki.folio.org/display/TC/Officially+Supported+Technologies) list.
     * _e.g. PostgreSQL, ElasticSearch, etc._
-

--- a/MODULE_SELF_EVALUATION.md
+++ b/MODULE_SELF_EVALUATION.md
@@ -1,0 +1,43 @@
+## Shared/Common
+* [x] Uses Apache 2.0 license
+* [x] Module build MUST produce a valid module descriptor
+* [x] Module descriptor MUST include interface requirements for all consumed APIs
+* [x] Third party dependencies use an Apache 2.0 compatible license
+* [x] Installation documentation is included
+    * -_note: read more at https://github.com/folio-org/mod-search/blob/master/README.md_
+* [] Personal data form is completed, accurate, and provided as `PERSONAL_DATA_DISCLOSURE.md` file
+* [] Sensitive and environment-specific information is not checked into git repository
+* [x] Module is written in a language and framework from the [officially approved technologies](https://wiki.folio.org/display/TC/Officially+Supported+Technologies) page
+* [x] Module only uses FOLIO interfaces already provided by previously accepted modules _e.g. a UI module cannot be accepted that relies on an interface only provided by a back end module that hasn't been accepted yet_
+* [x] Module gracefully handles the absence of third party systems or related configuration
+* [] Sonarqube hasn't identified any security issues, major code smells or excessive (>3%) duplication
+* [x] Uses [officially supported](https://wiki.folio.org/display/TC/Officially+Supported+Technologies) build tools
+* [] Unit tests have 80% coverage or greater, and are based on [officially approved technologies](https://wiki.folio.org/display/TC/Officially+Supported+Technologies)
+
+## Backend
+* [x] Module's repository includes a compliant Module Descriptor
+    * -_note: read more at https://github.com/folio-org/okapi/blob/master/okapi-core/src/main/raml/ModuleDescriptor.json_
+* [x] Module includes executable implementations of all endpoints in the provides section of the Module Descriptor
+* [] Environment vars are documented in the ModuleDescriptor
+    * -_note: read more at [https://wiki.folio.org/pages/viewpage.action?pageId=65110683](https://wiki.folio.org/pages/viewpage.action?pageId=65110683)_
+* [x] If a module provides interfaces intended to be consumed by other FOLIO Modules, they must be defined in the Module Descriptor "provides" section
+* [x] All API endpoints are documented in RAML or OpenAPI
+* [] All API endpoints protected with appropriate permissions as per the following guidelines and recommendations, e.g. avoid using `*.all` permissions, all necessary module permissions are assigned, etc.
+    * -_note: read more at https://dev.folio.org/guidelines/naming-conventions/ and https://wiki.folio.org/display/DD/Permission+Set+Guidelines_
+* [] Module provides reference data (if applicable), e.g. if there is a controlled vocabulary where the module requires at least one value
+* [] If provided, integration (API) tests must be written in an [officially approved technology](https://wiki.folio.org/display/TC/Officially+Supported+Technologies)
+    * -_note: while it's strongly recommended that modules implement integration tests, it's not a requirement_
+    * -_note: these tests are defined in https://github.com/folio-org/folio-integration-tests_
+* [] Data is segregated by tenant at the storage layer
+* [x] The module doesn't access data in DB schemas other than its own and public
+* [x] The module responds with a tenant's content based on x-okapi-tenant header
+* [x] Standard GET `/admin/health` endpoint returning a 200 response
+    * -_note: read more at https://wiki.folio.org/display/DD/Back+End+Module+Health+Check+Protocol_
+* [x] High Availability (HA) compliant
+    * Possible red flags:
+        * Connection affinity / sticky sessions / etc. are used
+        * Local container storage is used
+        * Services are stateful
+* [x] Module only uses infrastructure / platform technologies on the [officially approved technologies](https://wiki.folio.org/display/TC/Officially+Supported+Technologies) list.
+    * _e.g. PostgreSQL, ElasticSearch, etc._
+

--- a/MODULE_SELF_EVALUATION.md
+++ b/MODULE_SELF_EVALUATION.md
@@ -12,7 +12,7 @@
 * [x] Module gracefully handles the absence of third party systems or related configuration
 * [] Sonarqube hasn't identified any security issues, major code smells or excessive (>3%) duplication
 * [x] Uses [officially supported](https://wiki.folio.org/display/TC/Officially+Supported+Technologies) build tools
-* [] Unit tests have 80% coverage or greater, and are based on [officially approved technologies](https://wiki.folio.org/display/TC/Officially+Supported+Technologies)
+* [x] Unit tests have 80% coverage or greater, and are based on [officially approved technologies](https://wiki.folio.org/display/TC/Officially+Supported+Technologies)
 
 ## Backend
 * [x] Module's repository includes a compliant Module Descriptor

--- a/MODULE_SELF_EVALUATION.md
+++ b/MODULE_SELF_EVALUATION.md
@@ -10,7 +10,7 @@
 * [x] Module is written in a language and framework from the [officially approved technologies](https://wiki.folio.org/display/TC/Officially+Supported+Technologies) page
 * [x] Module only uses FOLIO interfaces already provided by previously accepted modules _e.g. a UI module cannot be accepted that relies on an interface only provided by a back end module that hasn't been accepted yet_
 * [x] Module gracefully handles the absence of third party systems or related configuration
-* [] Sonarqube hasn't identified any security issues, major code smells or excessive (>3%) duplication
+* [x] Sonarqube hasn't identified any security issues, major code smells or excessive (>3%) duplication
 * [x] Uses [officially supported](https://wiki.folio.org/display/TC/Officially+Supported+Technologies) build tools
 * [x] Unit tests have 80% coverage or greater, and are based on [officially approved technologies](https://wiki.folio.org/display/TC/Officially+Supported+Technologies)
 
@@ -22,10 +22,10 @@
     * -_note: read more at [https://wiki.folio.org/pages/viewpage.action?pageId=65110683](https://wiki.folio.org/pages/viewpage.action?pageId=65110683)_
 * [x] If a module provides interfaces intended to be consumed by other FOLIO Modules, they must be defined in the Module Descriptor "provides" section
 * [x] All API endpoints are documented in RAML or OpenAPI
-* [] All API endpoints protected with appropriate permissions as per the following guidelines and recommendations, e.g. avoid using `*.all` permissions, all necessary module permissions are assigned, etc.
+* [x] All API endpoints protected with appropriate permissions as per the following guidelines and recommendations, e.g. avoid using `*.all` permissions, all necessary module permissions are assigned, etc.
     * -_note: read more at https://dev.folio.org/guidelines/naming-conventions/ and https://wiki.folio.org/display/DD/Permission+Set+Guidelines_
 * [] Module provides reference data (if applicable), e.g. if there is a controlled vocabulary where the module requires at least one value
-* [] If provided, integration (API) tests must be written in an [officially approved technology](https://wiki.folio.org/display/TC/Officially+Supported+Technologies)
+* [x] If provided, integration (API) tests must be written in an [officially approved technology](https://wiki.folio.org/display/TC/Officially+Supported+Technologies)
     * -_note: while it's strongly recommended that modules implement integration tests, it's not a requirement_
     * -_note: these tests are defined in https://github.com/folio-org/folio-integration-tests_
 * [] Data is segregated by tenant at the storage layer

--- a/README.md
+++ b/README.md
@@ -132,3 +132,17 @@ FOLIO_CLIENT_TLS_TRUSTSTOREPATH=classpath:test/test.truststore.bcfks
 FOLIO_CLIENT_TLS_TRUSTSTOREPASSWORD=SecretPassword
 FOLIO_CLIENT_TLS_TRUSTSTORETYPE=bcfks
 ```
+
+## ASF Category B license notice
+
+Apache's [third-party license policy](https://www.apache.org/legal/resolved.html#category-b) allows Category B dependencies
+only under the conditions described there. The dependency license scan for this project reported the following dependencies
+whose detected licenses match ASF Category B license families:
+
+| Project | Detected dependency or dependencies | Detected license | Project URL |
+|---|---|---|---|
+| Jakarta Activation | `jakarta.activation:jakarta.activation-api:2.1.4` | EPL-1.0 | https://jakarta.ee/specifications/activation/ |
+| Jakarta XML Binding | `jakarta.xml.bind:jakarta.xml.bind-api:4.0.4` | EPL-1.0 | https://jakarta.ee/specifications/xml-binding/ |
+| Eclipse Sisu | `org.eclipse.sisu:org.eclipse.sisu.plexus:0.9.0.M2` | Eclipse Public License 1.0 | https://www.eclipse.org/sisu/ |
+| JUnit 6 | `org.junit.jupiter:junit-jupiter-api:6.0.3`, `org.junit.jupiter:junit-jupiter-engine:6.0.3`, `org.junit.jupiter:junit-jupiter-params:6.0.3`, `org.junit.platform:junit-platform-commons:6.0.3`, `org.junit.platform:junit-platform-engine:6.0.3` | EPL-2.0 | https://junit.org/junit5/ |
+| Mozilla Rhino | `org.mozilla:rhino:1.9.1` | Mozilla Public License 2.0 | https://github.com/mozilla/rhino |

--- a/README.md
+++ b/README.md
@@ -141,8 +141,8 @@ whose detected licenses match ASF Category B license families:
 
 | Project | Detected dependency or dependencies | Detected license | Project URL |
 |---|---|---|---|
-| Jakarta Activation | `jakarta.activation:jakarta.activation-api:2.1.4` | EPL-1.0 | https://jakarta.ee/specifications/activation/ |
-| Jakarta XML Binding | `jakarta.xml.bind:jakarta.xml.bind-api:4.0.4` | EPL-1.0 | https://jakarta.ee/specifications/xml-binding/ |
-| Eclipse Sisu | `org.eclipse.sisu:org.eclipse.sisu.plexus:0.9.0.M2` | Eclipse Public License 1.0 | https://www.eclipse.org/sisu/ |
-| JUnit 6 | `org.junit.jupiter:junit-jupiter-api:6.0.3`, `org.junit.jupiter:junit-jupiter-engine:6.0.3`, `org.junit.jupiter:junit-jupiter-params:6.0.3`, `org.junit.platform:junit-platform-commons:6.0.3`, `org.junit.platform:junit-platform-engine:6.0.3` | EPL-2.0 | https://junit.org/junit5/ |
-| Mozilla Rhino | `org.mozilla:rhino:1.9.1` | Mozilla Public License 2.0 | https://github.com/mozilla/rhino |
+| Jakarta Annotations API | `jakarta.annotation:jakarta.annotation-api:3.0.0` | EPL 2.0; GPL2 w/ CPE | https://projects.eclipse.org/projects/ee4j.ca |
+| Java Architecture for XML Binding | `javax.xml.bind:jaxb-api:2.3.1` | CDDL 1.1; GPL2 w/ CPE | https://github.com/javaee/jaxb-spec |
+| Eclipse Sisu | `org.eclipse.sisu:org.eclipse.sisu.plexus:0.9.0.M2` | Eclipse Public License, Version 1.0 | https://www.eclipse.org/sisu/ |
+| JUnit 6 | `org.junit.jupiter:junit-jupiter:6.0.3`, `org.junit.jupiter:junit-jupiter-api:6.0.3`, `org.junit.jupiter:junit-jupiter-engine:6.0.3`, `org.junit.jupiter:junit-jupiter-params:6.0.3`, `org.junit.platform:junit-platform-commons:6.0.3`, `org.junit.platform:junit-platform-engine:6.0.3` | Eclipse Public License v2.0 | https://junit.org/junit5/ |
+| Mozilla Rhino | `org.mozilla:rhino:1.9.1` | Mozilla Public License, Version 2.0 | https://github.com/mozilla/rhino |

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Institutional users should be granted the following permission in order to use t
 ## Configuration
 
 * See [edge-common](https://github.com/folio-org/edge-common) for a description of how configuration works.
+* See [ENV_VARS.md](ENV_VARS.md) for the environment variables declared by this module.
 
 ### TLS Configuration for HTTP Endpoints
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ See [edge-common-spring](https://github.com/folio-org/edge-common-spring)
 ## Requires Permissions
 
 Institutional users should be granted the following permission in order to use this edge API:
-- `"users.collection.get"`
-- `""users.item.post""`
+- `users.collection.get`
+- `users.item.post`
 
 ## Configuration
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -45,9 +45,9 @@
     },
     {
       "name": "FOLIO_CLIENT_OKAPIURL",
-      "value": "http://localhost:9130",
-      "description": "Okapi base URL used for outbound FOLIO service calls.",
-      "required": false
+      "value": "",
+      "description": "Okapi base URL used for outbound FOLIO service calls. This must be set to the reachable Okapi URL for the deployment environment.",
+      "required": true
     },
     {
       "name": "FOLIO_CLIENT_TLS_ENABLED",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -23,5 +23,6 @@
         "value": "-XX:MaxRAMPercentage=66.0"
       }
     ]
-  }
+  },
+  "env": []
 }

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -24,5 +24,96 @@
       }
     ]
   },
-  "env": []
+  "env": [
+    {
+      "name": "JAVA_OPTIONS",
+      "value": "-XX:MaxRAMPercentage=66.0",
+      "description": "Java runtime options for the module container.",
+      "required": false
+    },
+    {
+      "name": "SERVER_PORT",
+      "value": "8080",
+      "description": "HTTP port used by the embedded Spring Boot server.",
+      "required": false
+    },
+    {
+      "name": "FOLIO_ENVIRONMENT",
+      "value": "dev",
+      "description": "FOLIO environment name used by folio-spring-system-user configuration.",
+      "required": false
+    },
+    {
+      "name": "FOLIO_CLIENT_OKAPIURL",
+      "value": "http://localhost:9130",
+      "description": "Okapi base URL used for outbound FOLIO service calls.",
+      "required": false
+    },
+    {
+      "name": "FOLIO_CLIENT_TLS_ENABLED",
+      "value": "false",
+      "description": "Enables custom TLS truststore configuration for outbound Okapi/client calls.",
+      "required": false
+    },
+    {
+      "name": "FOLIO_CLIENT_TLS_TRUSTSTOREPATH",
+      "value": "",
+      "description": "Path to the outbound client TLS truststore. Required only when FOLIO_CLIENT_TLS_ENABLED is true and the server certificate is not trusted by the default JVM truststore.",
+      "required": false
+    },
+    {
+      "name": "FOLIO_CLIENT_TLS_TRUSTSTOREPASSWORD",
+      "value": "",
+      "description": "Password for the outbound client TLS truststore.",
+      "required": false
+    },
+    {
+      "name": "FOLIO_CLIENT_TLS_TRUSTSTORETYPE",
+      "value": "",
+      "description": "Type of the outbound client TLS truststore, for example JKS, PKCS12, or BCFKS. If unset, the JVM default truststore type is used.",
+      "required": false
+    },
+    {
+      "name": "SECURE_STORE_PROPS",
+      "value": "src/main/resources/ephemeral.properties",
+      "description": "Path or URL to the edge secure-store properties file used to configure the secure store for institutional user credentials.",
+      "required": false
+    },
+    {
+      "name": "API_KEY_SOURCES",
+      "value": "PARAM,HEADER,PATH",
+      "description": "Comma-separated list of locations where the edge API key is accepted. Valid values are PARAM, HEADER, and PATH.",
+      "required": false
+    },
+    {
+      "name": "TOKEN_CACHE_TTL_MS",
+      "value": "3600000",
+      "description": "Time to live, in milliseconds, for successful Okapi token cache entries.",
+      "required": false
+    },
+    {
+      "name": "NULL_TOKEN_CACHE_TTL_MS",
+      "value": "30000",
+      "description": "Time to live, in milliseconds, for failed or null Okapi token cache entries.",
+      "required": false
+    },
+    {
+      "name": "TOKEN_CACHE_CAPACITY",
+      "value": "100",
+      "description": "Maximum number of Okapi token entries held by the in-memory edge token cache.",
+      "required": false
+    },
+    {
+      "name": "EDGE_SECURITY_FILTER_ENABLED",
+      "value": "true",
+      "description": "Enables the edge API key security filter.",
+      "required": false
+    },
+    {
+      "name": "HEADER_EDGE_VALIDATION_EXCLUDE",
+      "value": "/admin/health,/admin/info,/swagger-resources,/v2/api-docs,/swagger-ui,/_/tenant",
+      "description": "Comma-separated list of request path prefixes excluded from edge API key validation.",
+      "required": false
+    }
+  ]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,9 @@
 
     <!-- Test dependencies versions -->
     <wiremock-standalone.version>3.13.2</wiremock-standalone.version>
+
+    <!-- Downgrade Liquibase to 4.33.0 to avoid FSL license in v5. This is the TC recommendation for new modules. -->
+    <liquibase.version>4.33.0</liquibase.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -238,7 +238,9 @@
               <generateSupportingFiles>true</generateSupportingFiles>
               <supportingFilesToGenerate>ApiUtil.java</supportingFilesToGenerate>
               <generateModelDocumentation>true</generateModelDocumentation>
-              <inlineSchemaNameDefaults>arrayItemSuffix=</inlineSchemaNameDefaults>
+              <inlineSchemaOptions>
+                <inlineSchemaOption>ARRAY_ITEM_SUFFIX=_inner</inlineSchemaOption>
+              </inlineSchemaOptions>
               <configOptions>
                 <java8>true</java8>
                 <dateLibrary>java</dateLibrary>

--- a/src/main/java/org/folio/edge/users/service/UserGroupService.java
+++ b/src/main/java/org/folio/edge/users/service/UserGroupService.java
@@ -1,0 +1,22 @@
+package org.folio.edge.users.service;
+
+import org.folio.edge.users.client.UserClient;
+import org.folio.users.domain.dto.UserGroup;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class UserGroupService {
+
+  private final UserClient userClient;
+
+  @Cacheable(value = "usergroup_cache", key = "{ #groupId }")
+  public UserGroup getUserGroupById(final String groupId) {
+    log.debug("Get user group by id '{}'", groupId);
+    return userClient.getGroupById(groupId);
+  }
+}

--- a/src/main/java/org/folio/edge/users/service/UsersService.java
+++ b/src/main/java/org/folio/edge/users/service/UsersService.java
@@ -8,14 +8,12 @@ import org.folio.users.domain.dto.AutomatedPatronBlock;
 import org.folio.users.domain.dto.ManualBlock;
 import org.folio.users.domain.dto.PatronPinWithId;
 import org.folio.users.domain.dto.RequestQueryParameters;
-import org.folio.users.domain.dto.UserGroup;
 import org.folio.users.domain.dto.UserResults;
 import org.folio.users.domain.dto.Userdata;
 import java.util.Objects;
 import java.util.function.Predicate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -34,6 +32,7 @@ public class UsersService {
   private final FeesFinesClient feesFinesClient;
   private final PatronBlocksClient patronBlocksClient;
   private final RequestQueryParametersMapper requestQueryParametersMapper;
+  private final UserGroupService userGroupService;
 
   public Userdata createUser(String lang, Userdata userdata) {
     return userClient.createUser(lang, userdata);
@@ -57,12 +56,6 @@ public class UsersService {
     return populateUserGroupName(userResults);
   }
 
-  @Cacheable(value = "usergroup_cache", key = "{ #groupId }")
-  public UserGroup getUserGroupById(final String groupId) {
-    log.debug("Get user group by id '{}'", groupId);
-    return userClient.getGroupById(groupId);
-  }
-
   private void populateBlockedAttribute(UserResults userResults) {
     userResults.getUsers().forEach(userdata -> {
       String userId = userdata.getId();
@@ -79,7 +72,7 @@ public class UsersService {
     userResults.getUsers().stream()
       .filter(userdata -> Objects.nonNull(userdata.getPatronGroup()))
       .forEach(userdata -> {
-        final UserGroup userGroup = getUserGroupById(userdata.getPatronGroup());
+        final var userGroup = userGroupService.getUserGroupById(userdata.getPatronGroup());
         log.debug("Retrieved user group by id '{}': '{}'", userdata.getPatronGroup(), userGroup);
         userdata.setPatronGroupName(userGroup.getGroup());
       });

--- a/src/test/java/org/folio/edge/users/TestUtil.java
+++ b/src/test/java/org/folio/edge/users/TestUtil.java
@@ -14,7 +14,7 @@ import org.apache.commons.io.IOUtils;
 public class TestUtil {
 
   public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
-      .setSerializationInclusion(Include.NON_NULL)
+      .setDefaultPropertyInclusion(Include.NON_NULL)
       .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
       .configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true)
       .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);

--- a/src/test/java/org/folio/edge/users/controller/UsersControllerIT.java
+++ b/src/test/java/org/folio/edge/users/controller/UsersControllerIT.java
@@ -154,7 +154,7 @@ class UsersControllerIT extends BaseIntegrationTests {
     mockMvc.perform(MockMvcRequestBuilders.post(TestConstant.PATRON_PIN_VERIFY_URI)
             .content(patronPinContent)
             .headers(defaultHeadersWithAuthorization()))
-        .andExpect(status().isUnprocessableEntity())
+        .andExpect(status().isUnprocessableContent())
         .andExpect(jsonPath("code", is(422)));
   }
 }

--- a/src/test/java/org/folio/edge/users/service/UserGroupServiceTest.java
+++ b/src/test/java/org/folio/edge/users/service/UserGroupServiceTest.java
@@ -1,0 +1,35 @@
+package org.folio.edge.users.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.folio.edge.users.client.UserClient;
+import org.folio.users.domain.dto.UserGroup;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserGroupServiceTest {
+
+  private static final String GROUP_ID = "3684a786-6671-4268-8ed0-9db82ebca60b";
+
+  @InjectMocks
+  private UserGroupService userGroupService;
+  @Mock
+  private UserClient userClient;
+
+  @Test
+  void getUserGroupById_shouldReturnUserGroup() {
+    var expectedUserGroup = new UserGroup().id(GROUP_ID).group("undergraduate");
+    when(userClient.getGroupById(GROUP_ID)).thenReturn(expectedUserGroup);
+
+    var actualUserGroup = userGroupService.getUserGroupById(GROUP_ID);
+
+    assertEquals(expectedUserGroup, actualUserGroup);
+    verify(userClient).getGroupById(GROUP_ID);
+  }
+}

--- a/src/test/java/org/folio/edge/users/service/UsersServiceTest.java
+++ b/src/test/java/org/folio/edge/users/service/UsersServiceTest.java
@@ -47,6 +47,8 @@ class UsersServiceTest {
   @Mock
   private RequestQueryParametersMapper requestQueryParametersMapper;
   @Mock
+  private UserGroupService userGroupService;
+  @Mock
   private Map<String, Object> requestQueryParametersMap;
 
   @BeforeEach
@@ -121,7 +123,7 @@ class UsersServiceTest {
     when(userClient.findUsers(requestQueryParametersMap)).thenReturn(expectedUserResults);
     var usergroupContent = TestUtil.readFileContentFromResources(TestConstant.USERGROUP_PATH);
     var expectedUserGroup = TestUtil.OBJECT_MAPPER.readValue(usergroupContent, UserGroup.class);
-    when(userClient.getGroupById(anyString())).thenReturn(expectedUserGroup);
+    when(userGroupService.getUserGroupById(anyString())).thenReturn(expectedUserGroup);
 
     var actualUserResults = usersService.getUsers(requestQueryParameters);
 
@@ -137,7 +139,7 @@ class UsersServiceTest {
     when(userClient.findUsers(requestQueryParametersMap)).thenReturn(expectedUserResults);
     var usergroupContent = TestUtil.readFileContentFromResources(TestConstant.USERGROUP_PATH);
     var expectedUserGroup = TestUtil.OBJECT_MAPPER.readValue(usergroupContent, UserGroup.class);
-    when(userClient.getGroupById(anyString())).thenReturn(expectedUserGroup);
+    when(userGroupService.getUserGroupById(anyString())).thenReturn(expectedUserGroup);
 
     var actualUserResults = usersService.getUsers(requestQueryParameters);
 
@@ -153,7 +155,7 @@ class UsersServiceTest {
     when(userClient.findUsers(requestQueryParametersMap)).thenReturn(expectedUserResults);
     var usergroupContent = TestUtil.readFileContentFromResources(TestConstant.USERGROUP_PATH);
     var expectedUserGroup = TestUtil.OBJECT_MAPPER.readValue(usergroupContent, UserGroup.class);
-    when(userClient.getGroupById(anyString())).thenReturn(expectedUserGroup);
+    when(userGroupService.getUserGroupById(anyString())).thenReturn(expectedUserGroup);
 
     var actualUserResults = usersService.getUsers(requestQueryParameters);
 
@@ -181,7 +183,7 @@ class UsersServiceTest {
         automatedPatronBlockResponse);
     var usergroupContent = TestUtil.readFileContentFromResources(TestConstant.USERGROUP_PATH);
     var expectedUserGroup = TestUtil.OBJECT_MAPPER.readValue(usergroupContent, UserGroup.class);
-    when(userClient.getGroupById(anyString())).thenReturn(expectedUserGroup);
+    when(userGroupService.getUserGroupById(anyString())).thenReturn(expectedUserGroup);
 
     var actualUserResults = usersService.getUsers(userRequestParam);
 
@@ -207,7 +209,7 @@ class UsersServiceTest {
         automatedPatronBlockResponse);
     var usergroupContent = TestUtil.readFileContentFromResources(TestConstant.USERGROUP_PATH);
     var expectedUserGroup = TestUtil.OBJECT_MAPPER.readValue(usergroupContent, UserGroup.class);
-    when(userClient.getGroupById(anyString())).thenReturn(expectedUserGroup);
+    when(userGroupService.getUserGroupById(anyString())).thenReturn(expectedUserGroup);
 
     var actualUserResults = usersService.getUsers(userRequestParam);
 


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/EDGEUSERS-17

Summary of TC requirement changes:
* Adds newly required env vars documentation
* Adds [Category B](https://www.apache.org/legal/resolved.html#category-b) license information to readme (also new requirement)
* Went through and checked off all the stuff in self eval file
* Updated PD disclosure per TC advice since this module _transmits_ PD
* Downgrade Liqubase to 4.33 per TC recommendation because it is no longer Category B but Category X in 5.x
* Add tc-evalution GH workflow
* Get rid of red squiggly in pom about `inlineSchemaNameDefaults` without changing behavior

Sonar fixes:
* Sonar didn't like that the old @Cacheable method was being called via `this`, so Spring’s proxy was bypassed. Moved it into an injected src/main/java/org/folio/edge/users/service/UserGroupService.java, so
  calls from src/main/java/org/folio/edge/users/service/UsersService.java now go through the Spring bean and the existing usergroup_cache advice can apply.
 * Changed deprecated calls:
   - setSerializationInclusion -> setDefaultPropertyInclusion
   - isUnprocessableEntity() -> isUnprocessableContent()